### PR TITLE
Add support for UpdatePolicy element in resource

### DIFF
--- a/lib/rubycfn.rb
+++ b/lib/rubycfn.rb
@@ -409,7 +409,8 @@ module Rubycfn
               Metadata: TOPLEVEL_BINDING.eval("@metadata"),
               Properties: TOPLEVEL_BINDING.eval("@properties"),
               Type: arguments[:type],
-              Condition: arguments[:condition]
+              Condition: arguments[:condition],
+              UpdatePolicy: arguments[:update_policy]
             }
           }
           TOPLEVEL_BINDING.eval("@aws_resources = @aws_resources.deep_merge(#{res})")

--- a/spec/lib/rubycfn_spec.rb
+++ b/spec/lib/rubycfn_spec.rb
@@ -14,6 +14,11 @@ describe Rubycfn do
 
       resource :rspec_resource_name,
                type: "Rspec::Test",
+               update_policy: {
+                 "AutoScalingReplacingUpdate": {
+                   "WillReplace": true
+                 }
+               },
                amount: 2 do |r|
         r.property(:name) { "RSpec" }
       end
@@ -54,6 +59,7 @@ describe Rubycfn do
 
         it { should have_key "Type" }
         it { should have_key "Properties" }
+        it { should have_key "UpdatePolicy"}
 
         context "resource type is correct" do
           let(:type) { resource["Type"] }
@@ -67,6 +73,13 @@ describe Rubycfn do
           subject { properties }
 
           it { should have_key "Name" }
+        end
+
+        context "Update policy is correct" do
+          let(:update_policy) { resource["UpdatePolicy"] }
+          subject { update_policy }
+
+          it { should include("AutoScalingReplacingUpdate" => { "WillReplace" => true })}
         end
       end
     end


### PR DESCRIPTION
This adds support for the very rare `UpdatePolicy` element on a resource (more info in [the docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html)). I had actually never encountered it in the wild before, until today. Happy happy joy joy.